### PR TITLE
Webpack Bundle compatibility issue fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a plugin for iOS that allows you to get a UUID (Universal Unique Identif
 
 Inspired from [`StackOverflow: How to preserve identifierForVendor in ios after uninstalling ios app on device?`] (http://stackoverflow.com/questions/21878560/how-to-preserve-identifierforvendor-in-ios-after-uninstalling-ios-app-on-device).
 
-Uses [`SSKeychain Cocoa Pod`](https://cocoapods.org/pods/SSKeychain).
+Uses [`SAMKeychain Cocoa Pod`](https://cocoapods.org/pods/SAMKeychain).
 
 ## Installation
 `tns plugin add nativescript-ios-uuid`

--- a/index.android.js
+++ b/index.android.js
@@ -1,0 +1,5 @@
+const platformModule = require("tns-core-modules/platform");
+
+exports.getUUID = function () {
+    return platformModule.device.uuid;
+};

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,9 +1,9 @@
 function getUUID() {
     var appName = NSBundle.mainBundle.infoDictionary.objectForKey(kCFBundleNameKey);
-    var strApplicationUUID = SSKeychain.passwordForServiceAccount(appName, "incoding");
+    var strApplicationUUID = SAMKeychain.passwordForServiceAccount(appName, "incoding");
     if (!strApplicationUUID){
         strApplicationUUID = UIDevice.currentDevice.identifierForVendor.UUIDString;
-        SSKeychain.setPasswordForServiceAccount(strApplicationUUID, appName, "incoding");
+        SAMKeychain.setPasswordForServiceAccount(strApplicationUUID, appName, "incoding");
     }
 
     return strApplicationUUID;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "nativescript": {
     "id": "org.nativescript.iosuuid",
     "platforms": {
-      "ios": "1.3.0"
+      "android": "3.0.0",
+      "ios": "3.0.0"
     }
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-ios-uuid",
   "version": "0.0.1",
   "description": "A NativeScript plugin for iOS that allows you to get a UUID (Universal Unique Identifier) for a device.",
-  "main": "index.js",
+  "main": "index",
   "nativescript": {
     "id": "org.nativescript.iosuuid",
     "platforms": {

--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'SSKeychain'
+pod 'SAMKeychain'


### PR DESCRIPTION
This extension is causing build problem if we need to use webpack bundle. [Depending to documentation](https://docs.nativescript.org/performance-optimizations/bundling-with-webpack#referencing-platform-specific-modules-from-packagejson) and my try removing file extension from main property of package.json fixes the issue. I hope this will not effect anything else.