### PR TITLE
Android support, upgrade to SAMKeychain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,32 @@
 
 This is a plugin for Nativescript that allows you to get a UUID (Universal Unique Identifier) for a device.
 
-Inspired from [`StackOverflow: How to preserve identifierForVendor in ios after uninstalling ios app on device?`] (http://stackoverflow.com/questions/21878560/how-to-preserve-identifierforvendor-in-ios-after-uninstalling-ios-app-on-device).
+Inspired from [`StackOverflow: How to preserve identifierForVendor in ios after uninstalling ios app on device?`](http://stackoverflow.com/questions/21878560/how-to-preserve-identifierforvendor-in-ios-after-uninstalling-ios-app-on-device).
 
-Uses [`SSKeychain Cocoa Pod`](https://cocoapods.org/pods/SSKeychain).
+Uses [`SAMKeychain Cocoa Pod`](https://cocoapods.org/pods/SAMKeychain).
 
 ## Installation
-`tns plugin add nativescript-uuid`
+
+Run the following command from the root of your project:
+
+```
+tns plugin add nativescript-uuid
+```
 
 ## Usage
+
+#### JavaScript
+```js
+  const nsUuid = require("nativescript-uuid");
+
+  const uuid = nsUuid.getUUID();
+  console.log(`The device UUID is ${uuid}`);
 ```
-var plugin = require("nativescript-uuid");
-var uuid = plugin.getUUID();
-console.log("The device UUID is " + uuid);
+
+#### TypeScript
+```typescript
+  import {getUUID} from 'nativescript-uuid';
+
+  const uuid = getUUID();
+  console.log(`The device UUID is ${uuid}`);
 ```

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# NativeScript iOS UUID
+# NativeScript UUID
 
-This is a plugin for iOS that allows you to get a UUID (Universal Unique Identifier) for a device.
+This is a plugin for Nativescript that allows you to get a UUID (Universal Unique Identifier) for a device.
 
 Inspired from [`StackOverflow: How to preserve identifierForVendor in ios after uninstalling ios app on device?`] (http://stackoverflow.com/questions/21878560/how-to-preserve-identifierforvendor-in-ios-after-uninstalling-ios-app-on-device).
 
 Uses [`SSKeychain Cocoa Pod`](https://cocoapods.org/pods/SSKeychain).
 
 ## Installation
-`tns plugin add nativescript-ios-uuid`
+`tns plugin add nativescript-uuid`
 
 ## Usage
 ```
-var plugin = require("nativescript-ios-uuid");
+var plugin = require("nativescript-uuid");
 var uuid = plugin.getUUID();
 console.log("The device UUID is " + uuid);
 ```

--- a/index.android.js
+++ b/index.android.js
@@ -1,4 +1,4 @@
-var device = require('../tns-core-modules/platform/platform');
+var device = require('tns-core-modules/platform/platform');
 
 function getUUID() {
   return device ? device.uuid : "";

--- a/index.android.js
+++ b/index.android.js
@@ -3,3 +3,5 @@ var device = require('platform');
 function getUUID() {
   return device ? device.uuid : "";
 }
+
+exports.getUUID = getUUID;

--- a/index.android.js
+++ b/index.android.js
@@ -1,4 +1,4 @@
-var device = require('platform');
+var device = require('../tns-core-modules/platform/platform');
 
 function getUUID() {
   return device ? device.uuid : "";

--- a/index.android.js
+++ b/index.android.js
@@ -1,0 +1,5 @@
+var device = require('platform');
+
+function getUUID() {
+  return device ? device.uuid : "";
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+
+
+
+export function getUUID(): string;

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,9 +1,9 @@
 function getUUID() {
     var appName = NSBundle.mainBundle.infoDictionary.objectForKey(kCFBundleNameKey);
-    var strApplicationUUID = SSKeychain.passwordForServiceAccount(appName, "incoding");
+    var strApplicationUUID = SAMKeychain.passwordForServiceAccount(appName, "incoding");
     if (!strApplicationUUID){
         strApplicationUUID = UIDevice.currentDevice.identifierForVendor.UUIDString;
-        SSKeychain.setPasswordForServiceAccount(strApplicationUUID, appName, "incoding");
+        SAMKeychain.setPasswordForServiceAccount(strApplicationUUID, appName, "incoding");
     }
 
     return strApplicationUUID;

--- a/package.json
+++ b/package.json
@@ -1,26 +1,24 @@
 {
-  "name": "nativescript-ios-uuid",
+  "name": "nativescript-uuid",
   "version": "0.0.1",
-  "description": "A NativeScript plugin for iOS that allows you to get a UUID (Universal Unique Identifier) for a device.",
+  "description": "A NativeScript plugin that allows you to get a UUID (Universal Unique Identifier) for a device.",
   "main": "index.js",
+  "type": "index.d.ts",
   "nativescript": {
-    "id": "org.nativescript.iosuuid",
+    "id": "org.nativescript.uuid",
     "platforms": {
-      "ios": "1.3.0"
+      "ios": "1.3.0",
+      "android": "1.3.0"
     }
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/hamorphis/nativescript-ios-uuid.git"
+    "url": "https://github.com/gdtdpt/nativescript-uuid.git"
   },
   "keywords": [
     "NativeScript",
-    "iOS",
     "UUID",
     "Device"
   ],
-  "author": "Rossen Hristov <rossen.hristov@telerik.com> (https://github.com/hamorphis)",
-  "license": "Apache-2.0",
-  "bugs": "https://github.com/hamorphis/nativescript-ios-uuid/issues",
-  "homepage": "https://github.com/hamorphis/nativescript-ios-uuid"
+  "license": "Apache-2.0"
 }

--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'SSKeychain'
+pod 'SAMKeychain', '~> 1.5.3'


### PR DESCRIPTION
Upgrade to SAMKeychain is critical because on iOS 12 an app which is using the plugin will crash immediately.